### PR TITLE
Replace `chdir` with `cd`

### DIFF
--- a/bin/w3c-validator-install.sh
+++ b/bin/w3c-validator-install.sh
@@ -34,7 +34,7 @@ else
     echo "Installing to $DST ...";
 fi
 
-chdir $DST;
+cd $DST;
 echo "Working dir is $PWD";
 
 if [ "x$ACTION" = "xall" -o "x$ACTION" = "xlibs" ]; then


### PR DESCRIPTION
Hi Jan,

`chdir` may not be available in all systems (not in my Gentoo Linux system). However, `cd` is a shell builtin.

Regards,
Alan Haggai Alavi.
